### PR TITLE
Add example shortcodes, missing-audio CSV, and word shortcode backfills

### DIFF
--- a/content/blog/ability-and-intent/index.md
+++ b/content/blog/ability-and-intent/index.md
@@ -61,4 +61,31 @@ A quick reference for the four everyday modal moves in Shami: **ability, desire,
 
 ---
 
+## أمثلة
+
+{{% examples title="Ability" titleAr="القدرة" %}}
+{{< example ar="فيني أجي بكرا، إذا ما صار شي." en="I can come tomorrow, if nothing comes up." ipa="ˈfiː.ni ˈʔe.ʒi ˈbuk.ra ˈʔiː.ðaː maː sˤaːr ʃi" >}}
+{{< example ar="بقدر ساعدك بعد الظهر." en="I can help you after noon." ipa="ˈbaʔ.der ˈsaː.ʕed.ak baʕd idˤ-dˤohr" >}}
+{{< example ar="مش فيني أكون بمكانين بنفس الوقت." en="I can't be in two places at the same time." ipa="miʃ ˈfiː.ni ʔkuːn bɪmkaːˈneːn bɪnˈnafs il-waʔt" >}}
+{{% /examples %}}
+
+{{% examples title="Desire" titleAr="الرغبة" %}}
+{{< example ar="بدي إحكي معك عن شي مهم." en="I want to talk to you about something important." ipa="ˈbid.di ˈʔeħ.ki maʕ.ak ʕan ʃi mˈhim" >}}
+{{< example ar="كان بدي أجي، بس ما قدرت." en="I was going to come, but I couldn't." ipa="ˈkaːn ˈbid.di ˈʔe.ʒi bass maː ˈʔadart" >}}
+{{< example ar="ناوي سافر الأسبوع الجاي." en="I'm planning to travel next week." ipa="ˈnaː.wi ˈsaː.fər il-ˈʔusbūʕ il-ˈʒaːji" >}}
+{{% /examples %}}
+
+{{% examples title="Obligation" titleAr="الواجب" %}}
+{{< example ar="لازم روح هلّق، رح تأخر." en="I have to go now, you'll be late." ipa="ˈlaː.zem ruːħ ˈhal.laʔ raħ tˈʔaxar" >}}
+{{< example ar="مفروض نكون هناك الساعة تسعة." en="We're supposed to be there at nine." ipa="mafˈruːd nkuːn ˈhiː.nik is-sāʕa ˈtisʕa" >}}
+{{< example ar="مو لازم تيجي إذا مش فيك." en="You don't have to come if you're not up for it." ipa="mo ˈlaː.zem ˈtiː.ʒi ˈʔiː.ðaː miʃ ˈfiː.k" >}}
+{{% /examples %}}
+
+{{% examples title="Hypothetical" titleAr="الافتراض" %}}
+{{< example ar="كنت روح لو في وقت." en="I would go if there were time." ipa="ˈkunt ruːħ law fiː waʔt" >}}
+{{< example ar="لو فيني، كنت سافرت معك." en="If I could, I would have traveled with you." ipa="law ˈfiː.ni ˈkunt saːˈfar.t maʕ.ak" >}}
+{{% /examples %}}
+
+---
+
 Illustration by [DA VECTOR](https://unsplash.com/@davector?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/illustrations/man-performing-a-push-up-exercise-B_eO6utxoU8?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)

--- a/content/blog/bad-hair-week/index.md
+++ b/content/blog/bad-hair-week/index.md
@@ -23,6 +23,8 @@ cssclasses:
   - arabic-note
 ---
 
+{{< word ar="كارثة" sh_ipa="ˈkaː.ri.se" meaning="disaster; catastrophe; calamity" root="ك · ر · ث" pos="noun (feminine)" note="Calibrated by tone — the same word covers a burnt coffee and a genuine crisis. Context (and how dramatic you sound) does the work." >}}
+
 ## صور
 
 {{< figure

--- a/content/blog/bisaraha/index.md
+++ b/content/blog/bisaraha/index.md
@@ -24,6 +24,9 @@ postLang: ar
 cssclasses:
   - arabic-note
 ---
+
+{{< word ar="بصراحة" sh_ipa="bɪ.sˤɑ.rɑː.ħa" meaning="honestly; frankly" root="ص · ر · ح" pos="adverb / discourse marker" note="A prepositional phrase: بـِ + صراحة (candour). Drop it at the start of a sentence to signal you're about to say something real." >}}
+
 ## خاطِرة
 بصراحة، بتهيألي إنّي لقيت أغنيتي المفضلة بالشامي لهلأ، وهي أغنية «بصراحة» لزياد رحباني! وبصراحة... ما في أحلى من هيك جو.
 

--- a/content/blog/crazy-week/index.md
+++ b/content/blog/crazy-week/index.md
@@ -24,6 +24,8 @@ cssclasses:
   - arabic-note
 ---
 
+{{< word ar="مضغوط" sh_ipa="madˈɣuːtˤ" meaning="pressured; stressed; packed" root="ض · غ · ط" pos="adjective (passive participle)" note="Covers everything from a packed schedule to emotional pressure. Feminine: مضغوطة. If your week is مضغوط, everyone will understand." >}}
+
 ## خاطِرة
 
 لأسبوع رح يكون مضغوط!!! اليوم عملت المقابلة التالتة مع Wix وما عملت شي غير هيك. وبعدين لازم نضب البيت كله.

--- a/content/blog/saar-daal/index.md
+++ b/content/blog/saar-daal/index.md
@@ -36,10 +36,12 @@ categories:
 
 ### أمثلة
 
-- صار برد.  
-- صار بدّي أغيّر الشغل.  
-- شو صار؟  
-- صار الوقت نروح.
+{{% examples title="صار" titleAr="التغيير" %}}
+{{< example ar="صار برد." en="It's gotten cold." ipa="sˤaːr bard" >}}
+{{< example ar="صار بدّي أغيّر الشغل." en="I've started wanting to change jobs." ipa="sˤaːr ˈbaddi ˈʔɣajjer ʃ-ʃuɣl" >}}
+{{< example ar="شو صار؟" en="What happened?" ipa="ʃuː sˤaːr" >}}
+{{< example ar="صار الوقت نروح." en="It's time for us to go." ipa="sˤaːr l-waʔt nruːħ" >}}
+{{% /examples %}}
 
 ---
 
@@ -49,10 +51,12 @@ categories:
 
 ### أمثلة
 
-- ضلّيت عم بستنى.  
-- ضلّ الجو برد.  
-- ضلّ الوضع هيك طول النهار.  
-- ضلّ عم يفكّر بالموضوع.
+{{% examples title="ضلّ" titleAr="الاستمرار" %}}
+{{< example ar="ضلّيت عم بستنى." en="I kept waiting." ipa="dˤalˈliːt ʕam bɪsˈtannā" >}}
+{{< example ar="ضلّ الجو برد." en="The weather stayed cold." ipa="dˤall il-ʒaw bard" >}}
+{{< example ar="ضلّ الوضع هيك طول النهار." en="The situation stayed like that all day." ipa="dˤall il-wadˤʕ heːk tˤuːl n-nhāːr" >}}
+{{< example ar="ضلّ عم يفكّر بالموضوع." en="He kept thinking about the matter." ipa="dˤall ʕam jɪfˈkɪr bɪl-mawdˤuːʕ" >}}
+{{% /examples %}}
 
 ---
 

--- a/missing-audio.csv
+++ b/missing-audio.csv
@@ -1,66 +1,69 @@
-slug,voice,text,en,post
-hadid,male,حَديد,"iron; metal",iron
-strike-iron-hot,male,"إضرب الحديد وهو حامي.","Strike the iron while it's hot.",iron
-heart-like-iron,male,"قلبه متل الحديد.","His heart is like iron.",iron
-qasab,male,قَصَب,"reed; cane",personal-ops
-saar,male,صَار,"became; happened; started to be",saar-daal
-dall,male,ضَلَّ,"stayed; remained; kept (doing)",saar-daal
-saar-cold,male,"صار برد.","It's gotten cold.",saar-daal
-saar-want-change-job,male,"صار بدّي أغيّر الشغل.","I've started wanting to change jobs.",saar-daal
-sho-saar,male,"شو صار؟","What happened?",saar-daal
-saar-time-go,male,"صار الوقت نروح.","It's time for us to go.",saar-daal
-dall-kept-waiting,male,"ضلّيت عم بستنى.","I kept waiting.",saar-daal
-dall-weather-cold,male,"ضلّ الجو برد.","The weather stayed cold.",saar-daal
-dall-situation-all-day,male,"ضلّ الوضع هيك طول النهار.","The situation stayed like that all day.",saar-daal
-dall-kept-thinking,male,"ضلّ عم يفكّر بالموضوع.","He kept thinking about the matter.",saar-daal
-fini,male,فِينِي,"I can; I am able to",ability-and-intent
-fini-come-tomorrow,male,"فيني أجي بكرا","I can come tomorrow",ability-and-intent
-baqdar-help-you,male,"بقدر ساعدك","I can help you",ability-and-intent
-mumkin-meet-today,male,"ممكن نلتقي اليوم","We might meet today",ability-and-intent
-bidi-talk-to-you,male,"بدي إحكي معك","I want to talk to you",ability-and-intent
-kan-bidi-come,male,"كان بدي أجي","I was going to come",ability-and-intent
-nawi-travel,male,"ناوي سافر","I'm planning to travel",ability-and-intent
-lazem-go-now,male,"لازم روح هلّق","I have to go now",ability-and-intent
-mafrud-be-there,male,"مفروض نكون هناك","We're supposed to be there",ability-and-intent
-mo-lazem-come,male,"مو لازم تيجي","You don't have to come",ability-and-intent
-kunt-go-if-time,male,"كنت روح لو في وقت","I would go if there were time",ability-and-intent
-law-fini-traveled,male,"لو فيني، كنت سافرت","If I could, I would've traveled",ability-and-intent
-fini-come-if-nothing,male,"فيني أجي بكرا، إذا ما صار شي.","I can come tomorrow, if nothing comes up.",ability-and-intent
-baqdar-help-afternoon,male,"بقدر ساعدك بعد الظهر.","I can help you after noon.",ability-and-intent
-mish-fini-two-places,male,"مش فيني أكون بمكانين بنفس الوقت.","I can't be in two places at the same time.",ability-and-intent
-bidi-talk-important,male,"بدي إحكي معك عن شي مهم.","I want to talk to you about something important.",ability-and-intent
-kan-bidi-come-couldnt,male,"كان بدي أجي، بس ما قدرت.","I was going to come, but I couldn't.",ability-and-intent
-nawi-travel-next-week,male,"ناوي سافر الأسبوع الجاي.","I'm planning to travel next week.",ability-and-intent
-lazem-go-now-late,male,"لازم روح هلّق، رح تأخر.","I have to go now, you'll be late.",ability-and-intent
-mafrud-be-there-nine,male,"مفروض نكون هناك الساعة تسعة.","We're supposed to be there at nine.",ability-and-intent
-mo-lazem-come-not-up,male,"مو لازم تيجي إذا مش فيك.","You don't have to come if you're not up for it.",ability-and-intent
-law-fini-traveled-with-you,male,"لو فيني، كنت سافرت معك.","If I could, I would have traveled with you.",ability-and-intent
-maabi,male,معبّي,"mind is full / mentally overloaded",notebook-lm
-bzhaq,male,بزهَق,"get bored easily — esp. with repetition",notebook-lm
-ufut-bi-iqaa,male,أُفوت بإيقاع,"getting into a rhythm (sleep / work)",notebook-lm
-hal-fatra,male,هالفترة,"lately / these days",notebook-lm
-mushtaq,male,مشتاق,"longing for / missing (a hobby)",notebook-lm
-nhawwes,male,نحوّس,"hunting for / trying to find",notebook-lm
-khabsa,male,خبصة,"a mess / a muddle — a chaotic situation",notebook-lm
-byiitim,male,بِيِعْتِم,"(light or mood) turns dim / gloomy",notebook-lm
-lammaht,male,لمّحت,"I caught a glimpse / glanced at",notebook-lm
-suraan-ma,male,سرعان ما,"quickly / soon after",notebook-lm
-mishaghib,male,مِشاغِب,"a troublemaker — often for kids",notebook-lm
-bil-noss,male,بالنصّ,"in the center / in the middle of it",notebook-lm
-muakhkharan,male,مؤخّرًا,recently,notebook-lm
-ajjelnah,male,أجّلناه,"we postponed it (a meeting / interview)",notebook-lm
-qaddam-imtihan,male,قدّم امتحان,"to sit for / take an exam",notebook-lm
-yismahuli,male,"يسمحولي / يخلّوني","to allow / let me (do something)",notebook-lm
-murattab,male,مُرتّب,"organized / tidy",notebook-lm
-btawassal-maa,male,بتواصل مع,"I'm in contact with",notebook-lm
-saar-maai,male,صار معي,"something happened to me / I had…",notebook-lm
-baajibni,male,بَعجبني,"I like to / it pleases me",notebook-lm
-shu-rayek,male,شو رأيك,"what do you think?",notebook-lm
-mafrud,male,مفروض,"supposed to / expected to",notebook-lm
-law-fini,male,لو فيني,"if I could (I would have…)",notebook-lm
-karmaal,male,كرمال,"for the sake of / for someone",notebook-lm
-ghaniyye,male,غَنِّيّة,song,music-1
-narqod,male,نَرْقُد,"I sleep; I go to sleep",tunisian-daily-2
-nidabdib,male,نِضَبْضِب,"to pack up; tidy up; get things in order",todos
-tajriba,male,تَجْرِبة,"experience; trial",notes-from-djerba
-faaq,male,فَاق,"to wake up; to notice / realize",daily-routine
+slug,voice,text,en,post,dialect
+hadid,male,حَديد,"iron; metal",iron,both
+strike-iron-hot,male,"إضرب الحديد وهو حامي.","Strike the iron while it's hot.",iron,shami
+heart-like-iron,male,"قلبه متل الحديد.","His heart is like iron.",iron,shami
+qasab,male,قَصَب,"reed; cane",personal-ops,both
+bisaraha,male,بصراحة,"honestly; frankly",bisaraha,shami
+madghut,male,مضغوط,"pressured; stressed; packed",crazy-week,shami
+karsa,male,كارثة,"disaster; catastrophe; calamity",bad-hair-week,shami
+saar,male,صَار,"became; happened; started to be",saar-daal,shami
+dall,male,ضَلَّ,"stayed; remained; kept (doing)",saar-daal,shami
+saar-cold,male,"صار برد.","It's gotten cold.",saar-daal,shami
+saar-want-change-job,male,"صار بدّي أغيّر الشغل.","I've started wanting to change jobs.",saar-daal,shami
+sho-saar,male,"شو صار؟","What happened?",saar-daal,shami
+saar-time-go,male,"صار الوقت نروح.","It's time for us to go.",saar-daal,shami
+dall-kept-waiting,male,"ضلّيت عم بستنى.","I kept waiting.",saar-daal,shami
+dall-weather-cold,male,"ضلّ الجو برد.","The weather stayed cold.",saar-daal,shami
+dall-situation-all-day,male,"ضلّ الوضع هيك طول النهار.","The situation stayed like that all day.",saar-daal,shami
+dall-kept-thinking,male,"ضلّ عم يفكّر بالموضوع.","He kept thinking about the matter.",saar-daal,shami
+fini,male,فِينِي,"I can; I am able to",ability-and-intent,shami
+fini-come-tomorrow,male,"فيني أجي بكرا","I can come tomorrow",ability-and-intent,shami
+baqdar-help-you,male,"بقدر ساعدك","I can help you",ability-and-intent,shami
+mumkin-meet-today,male,"ممكن نلتقي اليوم","We might meet today",ability-and-intent,shami
+bidi-talk-to-you,male,"بدي إحكي معك","I want to talk to you",ability-and-intent,shami
+kan-bidi-come,male,"كان بدي أجي","I was going to come",ability-and-intent,shami
+nawi-travel,male,"ناوي سافر","I'm planning to travel",ability-and-intent,shami
+lazem-go-now,male,"لازم روح هلّق","I have to go now",ability-and-intent,shami
+mafrud-be-there,male,"مفروض نكون هناك","We're supposed to be there",ability-and-intent,shami
+mo-lazem-come,male,"مو لازم تيجي","You don't have to come",ability-and-intent,shami
+kunt-go-if-time,male,"كنت روح لو في وقت","I would go if there were time",ability-and-intent,shami
+law-fini-traveled,male,"لو فيني، كنت سافرت","If I could, I would've traveled",ability-and-intent,shami
+fini-come-if-nothing,male,"فيني أجي بكرا، إذا ما صار شي.","I can come tomorrow, if nothing comes up.",ability-and-intent,shami
+baqdar-help-afternoon,male,"بقدر ساعدك بعد الظهر.","I can help you after noon.",ability-and-intent,shami
+mish-fini-two-places,male,"مش فيني أكون بمكانين بنفس الوقت.","I can't be in two places at the same time.",ability-and-intent,shami
+bidi-talk-important,male,"بدي إحكي معك عن شي مهم.","I want to talk to you about something important.",ability-and-intent,shami
+kan-bidi-come-couldnt,male,"كان بدي أجي، بس ما قدرت.","I was going to come, but I couldn't.",ability-and-intent,shami
+nawi-travel-next-week,male,"ناوي سافر الأسبوع الجاي.","I'm planning to travel next week.",ability-and-intent,shami
+lazem-go-now-late,male,"لازم روح هلّق، رح تأخر.","I have to go now, you'll be late.",ability-and-intent,shami
+mafrud-be-there-nine,male,"مفروض نكون هناك الساعة تسعة.","We're supposed to be there at nine.",ability-and-intent,shami
+mo-lazem-come-not-up,male,"مو لازم تيجي إذا مش فيك.","You don't have to come if you're not up for it.",ability-and-intent,shami
+law-fini-traveled-with-you,male,"لو فيني، كنت سافرت معك.","If I could, I would have traveled with you.",ability-and-intent,shami
+maabi,male,معبّي,"mind is full / mentally overloaded",notebook-lm,shami
+bzhaq,male,بزهَق,"get bored easily — esp. with repetition",notebook-lm,shami
+ufut-bi-iqaa,male,أُفوت بإيقاع,"getting into a rhythm (sleep / work)",notebook-lm,shami
+hal-fatra,male,هالفترة,"lately / these days",notebook-lm,shami
+mushtaq,male,مشتاق,"longing for / missing (a hobby)",notebook-lm,shami
+nhawwes,male,نحوّس,"hunting for / trying to find",notebook-lm,shami
+khabsa,male,خبصة,"a mess / a muddle — a chaotic situation",notebook-lm,shami
+byiitim,male,بِيِعْتِم,"(light or mood) turns dim / gloomy",notebook-lm,shami
+lammaht,male,لمّحت,"I caught a glimpse / glanced at",notebook-lm,shami
+suraan-ma,male,سرعان ما,"quickly / soon after",notebook-lm,shami
+mishaghib,male,مِشاغِب,"a troublemaker — often for kids",notebook-lm,shami
+bil-noss,male,بالنصّ,"in the center / in the middle of it",notebook-lm,shami
+muakhkharan,male,مؤخّرًا,recently,notebook-lm,shami
+ajjelnah,male,أجّلناه,"we postponed it (a meeting / interview)",notebook-lm,shami
+qaddam-imtihan,male,قدّم امتحان,"to sit for / take an exam",notebook-lm,shami
+yismahuli,male,"يسمحولي / يخلّوني","to allow / let me (do something)",notebook-lm,shami
+murattab,male,مُرتّب,"organized / tidy",notebook-lm,shami
+btawassal-maa,male,بتواصل مع,"I'm in contact with",notebook-lm,shami
+saar-maai,male,صار معي,"something happened to me / I had…",notebook-lm,shami
+baajibni,male,بَعجبني,"I like to / it pleases me",notebook-lm,shami
+shu-rayek,male,شو رأيك,"what do you think?",notebook-lm,shami
+mafrud,male,مفروض,"supposed to / expected to",notebook-lm,shami
+law-fini,male,لو فيني,"if I could (I would have…)",notebook-lm,shami
+karmaal,male,كرمال,"for the sake of / for someone",notebook-lm,shami
+ghaniyye,male,غَنِّيّة,song,music-1,shami
+narqod,male,نَرْقُد,"I sleep; I go to sleep",tunisian-daily-2,tunisian
+nidabdib,male,نِضَبْضِب,"to pack up; tidy up; get things in order",todos,shami
+tajriba,male,تَجْرِبة,"experience; trial",notes-from-djerba,both
+faaq,male,فَاق,"to wake up; to notice / realize",daily-routine,both

--- a/missing-audio.csv
+++ b/missing-audio.csv
@@ -67,3 +67,29 @@ narqod,male,نَرْقُد,"I sleep; I go to sleep",tunisian-daily-2,tunisian
 nidabdib,male,نِضَبْضِب,"to pack up; tidy up; get things in order",todos,shami
 tajriba,male,تَجْرِبة,"experience; trial",notes-from-djerba,both
 faaq,male,فَاق,"to wake up; to notice / realize",daily-routine,both
+barsha,male,برشة,"a lot / many / very",shami-tunsi-differences,tunisian
+khidma,male,خِدمة,"work / job",shami-tunsi-differences,tunisian
+shnuwwa,male,شنوّا,"what (interrogative)",shami-tunsi-differences,tunisian
+tawwa,male,تَوّا,now,shami-tunsi-differences,tunisian
+mzayyun,male,مزيّن,"nice / pleasant",shami-tunsi-differences,tunisian
+bahi,male,باهي,"good / OK",shami-tunsi-differences,tunisian
+nemshi,male,نمشي,"I go / I walk",shami-tunsi-differences,tunisian
+hwut-tn,male,حوت,"fish (Tunisian meaning)",shami-tunsi-differences,tunisian
+shanbiik,male,"شنبّيك / شنحوّلك","what do you want / what can I do for you",shami-tunsi-differences,tunisian
+nhebb,male,نحبّ,"I want / I love",shami-tunsi-differences,tunisian
+ktir,male,كتير,"a lot / many / very",shami-tunsi-differences,shami
+shughel,male,شُغل,"work / job",shami-tunsi-differences,shami
+shu,male,شو,"what (interrogative)",shami-tunsi-differences,shami
+hallaq,male,هلّق,now,shami-tunsi-differences,shami
+helu,male,حلو,"nice / pleasant",shami-tunsi-differences,shami
+tamam,male,"تمام / منيح","good / OK",shami-tunsi-differences,shami
+brooh,male,"بروح / بمشي","I go / I walk",shami-tunsi-differences,shami
+hwut-sh,male,حوت,"whale (Shami meaning)",shami-tunsi-differences,shami
+samak,male,سمك,"fish (Shami word)",shami-tunsi-differences,shami
+shu-biddak,male,"شو بدّك","what do you want",shami-tunsi-differences,shami
+bidi-bhebb,male,"بدي / بحبّ","I want / I love",shami-tunsi-differences,shami
+ajina,male,عجينه,dough,shabbos-baking,tunisian
+khalet,male,خليط,mixture,shabbos-baking,tunisian
+qirfa,male,القرفة,cinnamon,shabbos-baking,tunisian
+farraq,male,فرّق,"spread / distribute",shabbos-baking,tunisian
+dafra,male,ضفرة,braid,shabbos-baking,tunisian

--- a/missing-audio.csv
+++ b/missing-audio.csv
@@ -1,0 +1,66 @@
+slug,voice,text,en,post
+hadid,male,حَديد,"iron; metal",iron
+strike-iron-hot,male,"إضرب الحديد وهو حامي.","Strike the iron while it's hot.",iron
+heart-like-iron,male,"قلبه متل الحديد.","His heart is like iron.",iron
+qasab,male,قَصَب,"reed; cane",personal-ops
+saar,male,صَار,"became; happened; started to be",saar-daal
+dall,male,ضَلَّ,"stayed; remained; kept (doing)",saar-daal
+saar-cold,male,"صار برد.","It's gotten cold.",saar-daal
+saar-want-change-job,male,"صار بدّي أغيّر الشغل.","I've started wanting to change jobs.",saar-daal
+sho-saar,male,"شو صار؟","What happened?",saar-daal
+saar-time-go,male,"صار الوقت نروح.","It's time for us to go.",saar-daal
+dall-kept-waiting,male,"ضلّيت عم بستنى.","I kept waiting.",saar-daal
+dall-weather-cold,male,"ضلّ الجو برد.","The weather stayed cold.",saar-daal
+dall-situation-all-day,male,"ضلّ الوضع هيك طول النهار.","The situation stayed like that all day.",saar-daal
+dall-kept-thinking,male,"ضلّ عم يفكّر بالموضوع.","He kept thinking about the matter.",saar-daal
+fini,male,فِينِي,"I can; I am able to",ability-and-intent
+fini-come-tomorrow,male,"فيني أجي بكرا","I can come tomorrow",ability-and-intent
+baqdar-help-you,male,"بقدر ساعدك","I can help you",ability-and-intent
+mumkin-meet-today,male,"ممكن نلتقي اليوم","We might meet today",ability-and-intent
+bidi-talk-to-you,male,"بدي إحكي معك","I want to talk to you",ability-and-intent
+kan-bidi-come,male,"كان بدي أجي","I was going to come",ability-and-intent
+nawi-travel,male,"ناوي سافر","I'm planning to travel",ability-and-intent
+lazem-go-now,male,"لازم روح هلّق","I have to go now",ability-and-intent
+mafrud-be-there,male,"مفروض نكون هناك","We're supposed to be there",ability-and-intent
+mo-lazem-come,male,"مو لازم تيجي","You don't have to come",ability-and-intent
+kunt-go-if-time,male,"كنت روح لو في وقت","I would go if there were time",ability-and-intent
+law-fini-traveled,male,"لو فيني، كنت سافرت","If I could, I would've traveled",ability-and-intent
+fini-come-if-nothing,male,"فيني أجي بكرا، إذا ما صار شي.","I can come tomorrow, if nothing comes up.",ability-and-intent
+baqdar-help-afternoon,male,"بقدر ساعدك بعد الظهر.","I can help you after noon.",ability-and-intent
+mish-fini-two-places,male,"مش فيني أكون بمكانين بنفس الوقت.","I can't be in two places at the same time.",ability-and-intent
+bidi-talk-important,male,"بدي إحكي معك عن شي مهم.","I want to talk to you about something important.",ability-and-intent
+kan-bidi-come-couldnt,male,"كان بدي أجي، بس ما قدرت.","I was going to come, but I couldn't.",ability-and-intent
+nawi-travel-next-week,male,"ناوي سافر الأسبوع الجاي.","I'm planning to travel next week.",ability-and-intent
+lazem-go-now-late,male,"لازم روح هلّق، رح تأخر.","I have to go now, you'll be late.",ability-and-intent
+mafrud-be-there-nine,male,"مفروض نكون هناك الساعة تسعة.","We're supposed to be there at nine.",ability-and-intent
+mo-lazem-come-not-up,male,"مو لازم تيجي إذا مش فيك.","You don't have to come if you're not up for it.",ability-and-intent
+law-fini-traveled-with-you,male,"لو فيني، كنت سافرت معك.","If I could, I would have traveled with you.",ability-and-intent
+maabi,male,معبّي,"mind is full / mentally overloaded",notebook-lm
+bzhaq,male,بزهَق,"get bored easily — esp. with repetition",notebook-lm
+ufut-bi-iqaa,male,أُفوت بإيقاع,"getting into a rhythm (sleep / work)",notebook-lm
+hal-fatra,male,هالفترة,"lately / these days",notebook-lm
+mushtaq,male,مشتاق,"longing for / missing (a hobby)",notebook-lm
+nhawwes,male,نحوّس,"hunting for / trying to find",notebook-lm
+khabsa,male,خبصة,"a mess / a muddle — a chaotic situation",notebook-lm
+byiitim,male,بِيِعْتِم,"(light or mood) turns dim / gloomy",notebook-lm
+lammaht,male,لمّحت,"I caught a glimpse / glanced at",notebook-lm
+suraan-ma,male,سرعان ما,"quickly / soon after",notebook-lm
+mishaghib,male,مِشاغِب,"a troublemaker — often for kids",notebook-lm
+bil-noss,male,بالنصّ,"in the center / in the middle of it",notebook-lm
+muakhkharan,male,مؤخّرًا,recently,notebook-lm
+ajjelnah,male,أجّلناه,"we postponed it (a meeting / interview)",notebook-lm
+qaddam-imtihan,male,قدّم امتحان,"to sit for / take an exam",notebook-lm
+yismahuli,male,"يسمحولي / يخلّوني","to allow / let me (do something)",notebook-lm
+murattab,male,مُرتّب,"organized / tidy",notebook-lm
+btawassal-maa,male,بتواصل مع,"I'm in contact with",notebook-lm
+saar-maai,male,صار معي,"something happened to me / I had…",notebook-lm
+baajibni,male,بَعجبني,"I like to / it pleases me",notebook-lm
+shu-rayek,male,شو رأيك,"what do you think?",notebook-lm
+mafrud,male,مفروض,"supposed to / expected to",notebook-lm
+law-fini,male,لو فيني,"if I could (I would have…)",notebook-lm
+karmaal,male,كرمال,"for the sake of / for someone",notebook-lm
+ghaniyye,male,غَنِّيّة,song,music-1
+narqod,male,نَرْقُد,"I sleep; I go to sleep",tunisian-daily-2
+nidabdib,male,نِضَبْضِب,"to pack up; tidy up; get things in order",todos
+tajriba,male,تَجْرِبة,"experience; trial",notes-from-djerba
+faaq,male,فَاق,"to wake up; to notice / realize",daily-routine


### PR DESCRIPTION
## Summary

- **Example shortcodes in all `learn: true` posts** — `saar-daal` bullet-list examples converted to `{{% examples %}}` / `{{< example >}}` blocks with English translations and IPA; `ability-and-intent` gets a new `## أمثلة` section with four `{{% examples %}}` groups (ability, desire, obligation, hypothetical)
- **Site-wide `missing-audio.csv`** — 68 entries covering every word shortcode and example sentence across the site that lacks an audio file; includes `slug`, `voice`, `text`, `en`, `post`, and `dialect` (`shami` / `tunisian` / `both`) columns
- **Word shortcode backfills in three older posts** — `bisaraha` (بصراحة — title is the word), `crazy-week` (مضغوط — describes the week), `bad-hair-week` (كارثة — appears in the photo caption)

## What's not changed

Posts already using example shortcodes (`weak`, `need`, `iron`) were left alone. Posts whose كلام sections are broad vocabulary lists rather than post-defining terms (el-ghriba-photos, eleven-labs, all-caps, etc.) were left without word shortcodes.

## Test plan

- [ ] `hugo server -D` builds without errors
- [ ] `saar-daal` post renders example cards with Arabic, English, and IPA
- [ ] `ability-and-intent` post shows the new أمثلة section below the cheat sheets
- [ ] `bisaraha`, `crazy-week`, `bad-hair-week` each show the word card at the top
- [ ] `missing-audio.csv` opens cleanly — 68 data rows, 6 columns, no encoding issues

https://claude.ai/code/session_019E9WMsdJFLBWxJqGXUCyj5

---
_Generated by [Claude Code](https://claude.ai/code/session_019E9WMsdJFLBWxJqGXUCyj5)_