### PR TITLE
Fix: restore sitemap output and add robots.txt

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -30,6 +30,7 @@ outputs:
     - HTML
     - RSS
     - JSON
+    - Sitemap
 privacy:
   youTube:
     disable: false

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dailyderja.com/sitemap.xml


### PR DESCRIPTION
- Add Sitemap back to outputs.home (was dropped when JSON was added, silently stopping sitemap generation)
- Add static robots.txt pointing crawlers to sitemap URL


Claude-Session: https://claude.ai/code/session_019E9WMsdJFLBWxJqGXUCyj5